### PR TITLE
incorrect mod name

### DIFF
--- a/mod.conf
+++ b/mod.conf
@@ -1,1 +1,1 @@
-name = castles
+name = castle


### PR DESCRIPTION
The repository name is misleading
and the mod.conf file follows suit.

the mod wont start with "castles" in the mod.conf file
